### PR TITLE
Feature/Introduce a Database Session Class Using psycopg2

### DIFF
--- a/project/Dockerfile
+++ b/project/Dockerfile
@@ -1,6 +1,13 @@
 # pull official base image
 FROM python:3.8-slim-buster
 
+## install the gcc comiler dependencies
+## (to install psypcopg2-binary)
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y netcat-openbsd gcc && \
+    apt-get clean
+
 # set working directory
 WORKDIR /usr/src/app
 

--- a/project/app/api/dbsession.py
+++ b/project/app/api/dbsession.py
@@ -1,0 +1,142 @@
+import os
+import logging
+
+from dotenv import load_dotenv
+import psycopg2
+
+log = logging.getLogger(__name__)
+
+class DBSession:
+    """
+    Define a DBSession class that handles connecting to a Postgres database
+    and provides methods to test the connection and return a connection object
+    for use
+    """
+    
+    def __init__(self):
+        # Load environment variables
+        load_dotenv()
+        # Fetch environment variable values
+        self.DS_DB_USER     = os.getenv("DS_DB_USER")
+        self.DS_DB_PASSWORD = os.getenv("DS_DB_PASSWORD")
+        self.DS_DB_HOST     = os.getenv("DS_DB_HOST")
+        self.DS_DB_NAME     = os.getenv("DS_DB_NAME")
+        self.DS_DB_PORT     = os.getenv("DS_DB_PORT")
+        # Set up other instance values
+        self.dbconn         = None      # database connection object
+        self.valEnvVarsFlg  = False     # flag: validated env var values
+        self.valEnvVarsErr  = ""        # error: validated env var values
+        self.isConnectedFlg = False     # flag: successful db connection
+        
+    def valEnvVars(self):
+        """
+        Validate the Postgres database connection env vars
+        """
+        errMsg = []
+        if len(self.DS_DB_USER) == 0:
+            # DS_DB_USER is missing
+            errMsg.append("DS_DB_USER environment variable is missing")
+            
+        if len(self.DS_DB_PASSWORD) == 0:
+            # DS_DB_PASSWORD is missing
+            errMsg.append("DS_DB_PASSWORD environment variable is missing")
+            
+        if len(self.DS_DB_HOST) == 0:
+            # DS_DB_HOST is missing
+            errMsg.append("DS_DB_HOST environment variable is missing")
+            
+        if len(self.DS_DB_NAME) == 0:
+            # DS_DB_NAME is missing
+            errMsg.append("DS_DB_NAME environment variable is missing")
+            
+        if len(self.DS_DB_PORT) == 0:
+            # DS_DB_PORT is missing
+            errMsg.append("DS_DB_PORT environment variable is missing")
+            
+        if len(errMsg) != 0:
+            # one or more env vars are missing - return error message
+            self.valEnvVarsErr = "; ".join(errMsg)
+            self.valEnvVarsFlg = False
+            return self.valEnvVarsErr
+            
+        # No validation errors found - return None
+        self.valEnvVarsFlg = True
+        return None
+        
+    def connect(self):
+        """
+        Connect to the Postgres database
+        """
+        if self.isConnectedFlg:
+            # Already connected to the database
+            return "already connected to the database"
+            
+        if not self.valEnvVarsFlg:
+            # Invalid database environment variables
+            return "error: " + self.valEnvVarsErr
+            
+        # Configure a Postgres database connection object
+        self.dbconn = psycopg2.connect(user =        self.DS_DB_USER,
+                                       password =    self.DS_DB_PASSWORD,
+                                       host =        self.DS_DB_HOST,
+                                       port =        self.DS_DB_PORT,
+                                       database =    self.DS_DB_NAME)
+                                   
+        # Test the database connection
+        ret_str = ""
+        try:
+            cursor = self.dbconn.cursor()
+            # Print PostgreSQL Connection properties
+            log.info("Connecting to the database with these credentials: {conn_details}\n".format(conn_details=self.dbconn.get_dsn_parameters()))
+
+            # Print PostgreSQL version
+            cursor.execute("SELECT version();")
+            record = cursor.fetchone()
+            log.info("Successfully connected to the database: {conn_details}\n".format(conn_details=record))
+            self.isConnectedFlg = True
+            ret_str = record
+
+        except (Exception, psycopg2.Error) as error:
+            self.dbconn = None
+            self.isConnectedFlg = False
+            log.error("Error while connecting to PostgreSQL: {err}".format(err=error))
+            ret_str = "error: error connecting to the database: " + str(error)
+            
+        return ret_str
+        
+    def get_connection(self):
+        """
+        Return the instance's Postgres database connection
+        """
+        if not self.isConnectedFlg:
+            # No db connection exists
+            log.error("attempting to return a db connection but no connection is active")
+            return None
+            
+        return self.dbconn
+        
+    def test_connection(self):
+        """
+        Test the instance's current database connection
+        """
+        ret_str = ""
+        # Test the database connection
+        try:
+            cursor = self.dbconn.cursor()
+            # Print PostgreSQL Connection properties
+            log.info("Connecting to the database with these credentials: {conn_details}\n".format(conn_details=self.dbconn.get_dsn_parameters()))
+
+            # Print PostgreSQL version
+            cursor.execute("SELECT version();")
+            record = cursor.fetchone()
+            log.info("Successfully connected to the database: {conn_details}\n".format(conn_details=record))
+            self.isConnectedFlg = True
+            ret_str = record
+
+        except (Exception, psycopg2.Error) as error:
+            self.dbconn = None
+            self.isConnectedFlg = False
+            ret_str = "Error while connecting to PostgreSQL: {err}".format(err=error)
+            log.error(ret_str)
+        
+        return ret_str

--- a/project/app/api/dbsession.py
+++ b/project/app/api/dbsession.py
@@ -11,6 +11,21 @@ class DBSession:
     Define a DBSession class that handles connecting to a Postgres database
     and provides methods to test the connection and return a connection object
     for use
+
+    Usage:
+       # Create a database session object
+       db_sess = DBSession()
+
+       # Connect to the database
+       db_conn_attempt = db_sess.connect()
+
+       # Determine if any connection errors occurred
+       if db_conn_attempt["error"] == None:
+           # no errors connecting, assign the connection object for use
+           db_conn = db_conn_attempt["value"]
+       else:
+           # a connection error has occurred
+           # ... handle the connection error...
     """
     
     def __init__(self):
@@ -24,56 +39,63 @@ class DBSession:
         self.DS_DB_PORT     = os.getenv("DS_DB_PORT")
         # Set up other instance values
         self.dbconn         = None      # database connection object
+        self.valEnvVarErr   = []        # env var validation errors
         self.valEnvVarsFlg  = False     # flag: validated env var values
-        self.valEnvVarsErr  = ""        # error: validated env var values
         self.isConnectedFlg = False     # flag: successful db connection
-        
-    def valEnvVars(self):
-        """
-        Validate the Postgres database connection env vars
-        """
-        errMsg = []
+
+        # Validate the database connection environment variables
         if len(self.DS_DB_USER) == 0:
             # DS_DB_USER is missing
-            errMsg.append("DS_DB_USER environment variable is missing")
+            self.valEnvVarErr.append("DS_DB_USER environment variable is missing")
             
         if len(self.DS_DB_PASSWORD) == 0:
             # DS_DB_PASSWORD is missing
-            errMsg.append("DS_DB_PASSWORD environment variable is missing")
+            self.valEnvVarErr.append("DS_DB_PASSWORD environment variable is missing")
             
         if len(self.DS_DB_HOST) == 0:
             # DS_DB_HOST is missing
-            errMsg.append("DS_DB_HOST environment variable is missing")
+            self.valEnvVarErr.append("DS_DB_HOST environment variable is missing")
             
         if len(self.DS_DB_NAME) == 0:
             # DS_DB_NAME is missing
-            errMsg.append("DS_DB_NAME environment variable is missing")
+            self.valEnvVarErr.append("DS_DB_NAME environment variable is missing")
             
         if len(self.DS_DB_PORT) == 0:
             # DS_DB_PORT is missing
-            errMsg.append("DS_DB_PORT environment variable is missing")
+            self.valEnvVarErr.append("DS_DB_PORT environment variable is missing")
             
-        if len(errMsg) != 0:
+        # Are there any validation errors?
+        if len(self.valEnvVarErr) != 0:
             # one or more env vars are missing - return error message
-            self.valEnvVarsErr = "; ".join(errMsg)
-            self.valEnvVarsFlg = False
-            return self.valEnvVarsErr
-            
-        # No validation errors found - return None
-        self.valEnvVarsFlg = True
-        return None
+            log.error("error: one or more invalid env var values: {err_str}".format(err_str="; ".join(self.valEnvVarErr)))
+        else:
+            # no validation errors found 
+            self.valEnvVarsFlg = True
         
     def connect(self):
         """
         Connect to the Postgres database
+
+        Returns a dictionary
+          - "error": None if no connection error has occurred or an error message
+          - "value": database connection object or None if an error has occurred
         """
+        # Define a return dict
+        ret_dict = {
+            "error": None,
+            "value": None
+        }
         if self.isConnectedFlg:
             # Already connected to the database
-            return "already connected to the database"
+            log.info("attempting to connect to the database but a connection already exists")
+            ret_dict["value"] = self.dbconn
+            return ret_dict
             
         if not self.valEnvVarsFlg:
             # Invalid database environment variables
-            return "error: " + self.valEnvVarsErr
+            log.error("attempting to connect to the database one or more environment variables are invalid")
+            ret_dict["error"] = "invalid environment variables"
+            return ret_dict
             
         # Configure a Postgres database connection object
         self.dbconn = psycopg2.connect(user =        self.DS_DB_USER,
@@ -83,7 +105,6 @@ class DBSession:
                                        database =    self.DS_DB_NAME)
                                    
         # Test the database connection
-        ret_str = ""
         try:
             cursor = self.dbconn.cursor()
             # Print PostgreSQL Connection properties
@@ -94,49 +115,55 @@ class DBSession:
             record = cursor.fetchone()
             log.info("Successfully connected to the database: {conn_details}\n".format(conn_details=record))
             self.isConnectedFlg = True
-            ret_str = record
+            ret_dict["value"] = self.dbconn
 
         except (Exception, psycopg2.Error) as error:
             self.dbconn = None
             self.isConnectedFlg = False
             log.error("Error while connecting to PostgreSQL: {err}".format(err=error))
-            ret_str = "error: error connecting to the database: " + str(error)
+            ret_dict["error"] = "error: error connecting to the database: " + str(error)
+            ret_dict["value"] = None
             
-        return ret_str
-        
-    def get_connection(self):
-        """
-        Return the instance's Postgres database connection
-        """
-        if not self.isConnectedFlg:
-            # No db connection exists
-            log.error("attempting to return a db connection but no connection is active")
-            return None
-            
-        return self.dbconn
+        return ret_dict
         
     def test_connection(self):
         """
         Test the instance's current database connection
+
+        Returns a dictionary
+          - "error": None if no connection error has occurred or an error message
+          - "value": the database version or None if an error has occurred
         """
-        ret_str = ""
+        # Define a return dict
+        ret_dict = {
+            "error": None,
+            "value": None
+        }
         # Test the database connection
         try:
             cursor = self.dbconn.cursor()
-            # Print PostgreSQL Connection properties
-            log.info("Connecting to the database with these credentials: {conn_details}\n".format(conn_details=self.dbconn.get_dsn_parameters()))
 
             # Print PostgreSQL version
             cursor.execute("SELECT version();")
             record = cursor.fetchone()
             log.info("Successfully connected to the database: {conn_details}\n".format(conn_details=record))
             self.isConnectedFlg = True
-            ret_str = record
+            ret_dict["value"] = record
 
         except (Exception, psycopg2.Error) as error:
             self.dbconn = None
             self.isConnectedFlg = False
-            ret_str = "Error while connecting to PostgreSQL: {err}".format(err=error)
-            log.error(ret_str)
+            log.error("Error while connecting to PostgreSQL: {err}".format(err=error))
+            ret_dict["error"] = "error connecting to the database: {err}".format(err=error)
+            ret_dict["value"] = None
         
-        return ret_str
+        return ret_dict
+
+    def close_connection(self):
+        """
+        Close the instance's current database connection
+        """
+        if self.dbconn != None:
+            self.dbconn.close()
+
+        return

--- a/project/app/api/predict.py
+++ b/project/app/api/predict.py
@@ -13,7 +13,7 @@ import datetime
 from sodapy import Socrata
 from datetime import timedelta
 
-from .dbsession import DBSession
+from app.api.dbsession import DBSession
 
 log = logging.getLogger(__name__)
 router = APIRouter()
@@ -35,20 +35,19 @@ class Item(BaseModel):
         assert value > 0, f'x1 == {value}, must be > 0'
         return value
 
-# Test creating a db connection
+# Create a database session object
 db_sess = DBSession()
-# Validate the database connection details
-valEnvVars = db_sess.valEnvVars()
-if valEnvVars != None:
-    # error: missing some database environment variables
-    print("error: " + valEnvVars)
+
 # Connect to the database
-db_sess.connect()
-if db_sess.isConnectedFlg:
-    # grab a database connection
-    db_conn = db_sess.get_connection()
+db_conn_attempt = db_sess.connect()
+
+# Determine if any connection errors occurred
+if db_conn_attempt["error"] == None:
+    # no errors connecting, assign the connection object for use
+    db_conn = db_conn_attempt["value"]
 else:
-    print("error: database connection failed")
+    # a connection error has occurred
+    log.error("error attempting to connect to the database: {err_str}".format(err_str=db_conn_attempt["error"]))
 
 @router.get('/db_test')
 async def db_test():

--- a/project/requirements.txt
+++ b/project/requirements.txt
@@ -5,5 +5,6 @@ uvicorn==0.11.8
 sodapy==2.1.0
 scikit-learn==0.23.2
 requests==2.24.0
-python-dotenv == 0.15.0
+python-dotenv==0.15.0
+psycopg2-binary==2.8.6
 


### PR DESCRIPTION
This PR defines a Postgres database session class that is invoked to create a database session object.  A method is called to connect to the database and return `psycopg2` connection object that can then used by other functions such as FastAPI route handlers

The session class (`DBSession`) houses these methods:
* `valEnvVars`: validate the environment variable values that are used to connect to the hosted Postgres database
* `connect`: connect to the database and establish a connection object
* `get_connection`: return the connection object (if it exists) for use in the application
* `test_connection`: test the existing connection and return feedback from the test
* `close_connection`: close the existing connection

