### PR TITLE
Feature/Enable the Fetching of Pre-Generated State Covid Deltas from the Database

### DIFF
--- a/project/app/api/constants.py
+++ b/project/app/api/constants.py
@@ -52,8 +52,7 @@ STATE_POP = {
     "WV": 1792147,
     "WY": 578759}
 
-
- statecodes = [
+statecodes = [
         'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'DC', 'FL', 
         'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME',
         'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 

--- a/project/app/api/constants.py
+++ b/project/app/api/constants.py
@@ -51,3 +51,12 @@ STATE_POP = {
     "WI": 5822434,
     "WV": 1792147,
     "WY": 578759}
+
+
+ statecodes = [
+        'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'DC', 'FL', 
+        'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME',
+        'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 
+        'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI',
+        'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI',
+        'WY']

--- a/project/app/api/predict.py
+++ b/project/app/api/predict.py
@@ -6,13 +6,13 @@ import pandas as pd
 from pydantic import BaseModel, Field, validator
 import psycopg2
 
-
 import os 
 from dotenv import load_dotenv
 import pandas as pd
 import datetime
 from sodapy import Socrata
-from datetime import timedelta
+from datetime import datetime, timedelta
+import pytz
 import warnings
 from joblib import load
 
@@ -21,7 +21,6 @@ import json
 from app.airbnb_helper_files.worker import return_avg_price
 
 from app.api import gas_price
-
 
 from app.api.dbsession import DBSession
 import app.api.covid_score as scr
@@ -160,6 +159,62 @@ async def covid_by_state(state: covid_state):
     new= df[(df['state'] == state.state) & (df['submission_date'] > last_week)]
     new_cases= new['new_case'].astype('float').sum()
     return new_cases
+
+@router.post('/gen_covid_deltas')
+async def gen_covid_deltas():
+    """
+    Generate covid deltas for all states and save to the database in
+    table `state_covid_deltas_daily` as a pre-generated value to be used 
+    downstream
+
+    ### Response
+        - `ok`:       boolean indicating a successful request
+        - `date`:     today's date which is associated with this data
+        - `data`:     the covid deltas data stored to the database
+        - `error`:    error message (if applicable)
+    """
+    ret_dict = {
+        "ok":    False,
+        "date":  None,
+        "data":  None,
+        "error": "no data to report"
+    }
+
+    # Generate the covid deltas data for each state  
+    covid_deltas_data = scr.calc_covid_deltas(db_conn)
+
+    # Validated that some data was returned
+    if len(covid_deltas_data) < 50:
+        # Have less than 50 entries in data, assume an error occurred
+        ret_dict["error"] = "invalid data - less than 50 state entries"
+        ret_dict["data"]  = covid_deltas_data
+        return ret_dict
+
+    # Insert the deltas data into the database
+    # Get today's date
+    today_PT = datetime.now(pytz.timezone('US/Pacific')).strftime("%Y-%m-%d")
+
+    # Insert the pre-generated data into the database
+    sql = "INSERT INTO state_covid_deltas_daily (date, is_valid, json_doc) VALUES (%s, TRUE, %s) ON CONFLICT (date) DO NOTHING"
+    try:
+        # Attempt the insert
+        cursor = db_conn.cursor()
+        cursor.execute(sql, (today_PT, json.dumps(covid_deltas_data)))
+        # commit the db changes
+        db_conn.commit()
+
+    except (Exception, psycopg2.Error) as error:
+        # Error inserting calc_covid_deltas values into the database
+        print(f"INFO: error inserting calc_covid_deltas values stored in the database. See: {error}")
+        ret_dict["error"] = "error inserting into the database; see: " + str(error)
+        return ret_dict
+
+    # Data successfully inserted into the database
+    ret_dict["ok"]    = True
+    ret_dict["date"]  = today_PT
+    ret_dict["data"]  = covid_deltas_data
+    ret_dict["error"] = None
+    return ret_dict
 
 @router.post('/airbnb')
 async def airbnb_price(airbnb : Airbnb_Loc):

--- a/project/app/api/predict.py
+++ b/project/app/api/predict.py
@@ -230,4 +230,3 @@ def get_gas_price_state(ste):
     return data_dict['result']['state']
 
 
-

--- a/project/app/api/viz.py
+++ b/project/app/api/viz.py
@@ -24,7 +24,7 @@ async def viz(statecode: str):
     JSON string to render with [react-plotly.js](https://plotly.com/javascript/react/) 
     """
 
-    df3 = viz_readiness(STATE_POP, state_codes)
+    df3 = viz_readiness(STATE_POP, statecodes)
 
     fig = go.Figure(data=go.Choropleth(
     locations=df3['index'], # Spatial coordinates

--- a/project/app/api/viz.py
+++ b/project/app/api/viz.py
@@ -44,17 +44,12 @@ async def viz(statecode: str):
     return fig.to_json()
 
 @router.get('/viz/covid_score')
-async def viz_covid(statecode: str):
+async def viz_covid():
     """
     Visualize covid score based off of covid cases reported in the last 14 days to the CDC
-    
-    ### Path Parameter
-    `statecode`: The [USPS 2 letter abbreviation](https://en.wikipedia.org/wiki/List_of_U.S._state_and_territory_abbreviations#Table) 
-    (case insensitive) for any of the 50 states or the District of Columbia.
 
     ### Response
     JSON string to render with [react-plotly.js](https://plotly.com/javascript/react/
-
     """
     df3 = viz_readiness_covid_score(STATE_POP)
 

--- a/project/app/api/viz.py
+++ b/project/app/api/viz.py
@@ -4,8 +4,10 @@ import datetime
 from sodapy import Socrata
 from datetime import timedelta
 from app.api.constants import STATE_POP, statecodes
-from app.api.viz_prep import viz_readiness
+from app.api.viz_prep import viz_readiness, viz_readiness_covid_score
 import plotly.graph_objects as go
+import os 
+from dotenv import load_dotenv
 
 
 router = APIRouter()
@@ -54,4 +56,19 @@ async def viz_covid(statecode: str):
     JSON string to render with [react-plotly.js](https://plotly.com/javascript/react/
 
     """
+    df3 = viz_readiness_covid_score(STATE_POP)
+
+    fig = go.Figure(data=go.Choropleth(
+    locations=df3['index'], # Spatial coordinates
+    z = df3['covid_score'].astype(float), # Data to be color-coded
+    locationmode = 'USA-states', # set of locations match entries in `locations`
+    colorscale = 'Reds',
+    colorbar_title = "Covid Score: Statistical Difference in Covid Cases",
+    ))
+
+    fig.update_layout(
+        title_text = 'Covid Score by State',
+        geo_scope='usa', # limite map scope to USA
+    )
+
     return fig.to_json()

--- a/project/app/api/viz.py
+++ b/project/app/api/viz.py
@@ -1,14 +1,20 @@
 from fastapi import APIRouter, HTTPException
 import pandas as pd
-import plotly.express as px
+import datetime
+from sodapy import Socrata
+from datetime import timedelta
+from app.api.constants import STATE_POP, statecodes
+from app.api.viz_prep import viz_readiness
+import plotly.graph_objects as go
+
 
 router = APIRouter()
 
 
-@router.get('/viz/{statecode}')
+@router.get('/viz/covid_pop')
 async def viz(statecode: str):
     """
-    Visualize state unemployment rate from [Federal Reserve Economic Data](https://fred.stlouisfed.org/) 📈
+    Visualize covid cases reported to the CDC in last 14 days per state population 
     
     ### Path Parameter
     `statecode`: The [USPS 2 letter abbreviation](https://en.wikipedia.org/wiki/List_of_U.S._state_and_territory_abbreviations#Table) 
@@ -18,37 +24,31 @@ async def viz(statecode: str):
     JSON string to render with [react-plotly.js](https://plotly.com/javascript/react/) 
     """
 
-    # Validate the state code
-    statecodes = {
-        'AL': 'Alabama', 'AK': 'Alaska', 'AZ': 'Arizona', 'AR': 'Arkansas', 
-        'CA': 'California', 'CO': 'Colorado', 'CT': 'Connecticut', 
-        'DE': 'Delaware', 'DC': 'District of Columbia', 'FL': 'Florida', 
-        'GA': 'Georgia', 'HI': 'Hawaii', 'ID': 'Idaho', 'IL': 'Illinois', 
-        'IN': 'Indiana', 'IA': 'Iowa', 'KS': 'Kansas', 'KY': 'Kentucky', 
-        'LA': 'Louisiana', 'ME': 'Maine', 'MD': 'Maryland', 
-        'MA': 'Massachusetts', 'MI': 'Michigan', 'MN': 'Minnesota', 
-        'MS': 'Mississippi', 'MO': 'Missouri', 'MT': 'Montana', 
-        'NE': 'Nebraska', 'NV': 'Nevada', 'NH': 'New Hampshire', 
-        'NJ': 'New Jersey', 'NM': 'New Mexico', 'NY': 'New York', 
-        'NC': 'North Carolina', 'ND': 'North Dakota', 'OH': 'Ohio', 
-        'OK': 'Oklahoma', 'OR': 'Oregon', 'PA': 'Pennsylvania', 
-        'RI': 'Rhode Island', 'SC': 'South Carolina', 'SD': 'South Dakota', 
-        'TN': 'Tennessee', 'TX': 'Texas', 'UT': 'Utah', 'VT': 'Vermont', 
-        'VA': 'Virginia', 'WA': 'Washington', 'WV': 'West Virginia', 
-        'WI': 'Wisconsin', 'WY': 'Wyoming'
-    }
-    statecode = statecode.upper()
-    if statecode not in statecodes:
-        raise HTTPException(status_code=404, detail=f'State code {statecode} not found')
+    df3 = viz_readiness(STATE_POP, state_codes)
 
-    # Get the state's unemployment rate data from FRED
-    url = f'https://fred.stlouisfed.org/graph/fredgraph.csv?id={statecode}UR'
-    df = pd.read_csv(url, parse_dates=['DATE'])
-    df.columns = ['Date', 'Percent']
+    fig = go.Figure(data=go.Choropleth(
+    locations=df3['index'], # Spatial coordinates
+    z = df3['covid_case_per_pop'].astype(float), # Data to be color-coded
+    locationmode = 'USA-states', # set of locations match entries in `locations`
+    colorscale = 'Reds',
+    colorbar_title = "Covid by Population",
+    ))
 
-    # Make Plotly figure
-    statename = statecodes[statecode]
-    fig = px.line(df, x='Date', y='Percent', title=f'{statename} Unemployment Rate')
+    fig.update_layout(
+        title_text = 'Current US Covid Cases by State',
+        geo_scope='usa', # limite map scope to USA
+    )
 
-    # Return Plotly figure as JSON string
     return fig.to_json()
+
+@router.get('/viz/covid_score')
+async def viz_covid(statecode: str):
+    """
+    Visualize covid score based off of covid cases reported in the last 14 days to the CDC
+    
+    ### Path Parameter
+    `statecode`: The [USPS 2 letter abbreviation](https://en.wikipedia.org/wiki/List_of_U.S._state_and_territory_abbreviations#Table) 
+    (case insensitive) for any of the 50 states or the District of Columbia.
+
+    ### Response
+    JSON string to render with [react-plotly.js](https://plotly.com/javascript/react/

--- a/project/app/api/viz.py
+++ b/project/app/api/viz.py
@@ -52,3 +52,6 @@ async def viz_covid(statecode: str):
 
     ### Response
     JSON string to render with [react-plotly.js](https://plotly.com/javascript/react/
+
+    """
+    return fig.to_json()

--- a/project/app/api/viz_prep.py
+++ b/project/app/api/viz_prep.py
@@ -4,7 +4,7 @@ from sodapy import Socrata
 from datetime import timedelta
 from app.api import constants
 from app.api.dbsession import DBSession
-from app.api.covid_score import calc_covid_deltas
+from app.api.covid_score import calc_covid_deltas_db
 import os
 
 def viz_readiness(state_pops, state_codes):
@@ -56,7 +56,8 @@ def viz_readiness_covid_score(state_pops):
   # a connection error has occurred
       log.error("error attempting to connect to the database: {err_str}".format(err_str=db_conn_attempt["error"]))
 
-  covid_score_dict = calc_covid_deltas(db_conn)
+  # covid_score_dict = calc_covid_deltas(db_conn)
+  covid_score_dict = calc_covid_deltas_db(db_conn)
 
   df = pd.DataFrame.from_dict(covid_score_dict, orient='index')
   df = df.reset_index()

--- a/project/app/api/viz_prep.py
+++ b/project/app/api/viz_prep.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from app.api import constants
 from app.api.dbsession import DBSession
 from app.api.covid_score import calc_covid_deltas
+import os
 
 def viz_readiness(state_pops, state_codes):
   MY_APP_TOKEN = str(os.getenv("COVID_API"))
@@ -40,31 +41,31 @@ def viz_readiness(state_pops, state_codes):
 
   return df3
 
-  def viz_readiness_covid_score(state_pops):
+def viz_readiness_covid_score(state_pops):
       # Create a database session object
-    db_sess = DBSession()
+  db_sess = DBSession()
 
-    # Connect to the database
-    db_conn_attempt = db_sess.connect()
+  # Connect to the database
+  db_conn_attempt = db_sess.connect()
 
-    # Determine if any connection errors occurred
-    if db_conn_attempt["error"] == None:
-    # no errors connecting, assign the connection object for use
-        db_conn = db_conn_attempt["value"]
-    else:
-    # a connection error has occurred
-        log.error("error attempting to connect to the database: {err_str}".format(err_str=db_conn_attempt["error"]))
+  # Determine if any connection errors occurred
+  if db_conn_attempt["error"] == None:
+  # no errors connecting, assign the connection object for use
+      db_conn = db_conn_attempt["value"]
+  else:
+  # a connection error has occurred
+      log.error("error attempting to connect to the database: {err_str}".format(err_str=db_conn_attempt["error"]))
 
-    covid_score_dict = calc_covid_deltas(db_conn)
+  covid_score_dict = calc_covid_deltas(db_conn)
 
-    df = pd.DataFrame.from_dict(covid_score_dict, orient='index')
-    df.reset_index()
-    df2 = pd.DataFrame.from_dict(state_pops, orient='index')
-    df2.reset_index()
-    df3 = pd.concat([df, df2], axis=1)
-    df3.columns = ['covid_score', 'population']
-
-    return df3
+  df = pd.DataFrame.from_dict(covid_score_dict, orient='index')
+  df = df.reset_index()
+  # df2 = pd.DataFrame.from_dict(state_pops, orient='index')
+  # df2.reset_index()
+  # df3 = pd.concat([df, df2], axis=1)
+  #df3.columns = ['covid_score', 'population']
+  df.columns = ["index", "covid_score"]
+  return df
 
 # df3 = viz_readiness_covid_score(STATE_POPS)
 # print(df3.head())

--- a/project/app/api/viz_prep.py
+++ b/project/app/api/viz_prep.py
@@ -1,0 +1,38 @@
+import datetime
+from sodapy import Socrata
+from datetime import timedelta
+from app.api.constants import STATE_POP, statecodes
+
+def viz_readiness(state_pops, state_codes):
+  MY_APP_TOKEN = str(os.getenv("COVID_API"))
+  client = Socrata('data.cdc.gov',MY_APP_TOKEN)
+  q = '''
+    SELECT * 
+    ORDER BY submission_date DESC
+    LIMIT 1000
+    '''
+  results = client.get("9mfq-cb36", query = q)
+  df = pd.DataFrame.from_records(results)
+    
+
+  last_week = str(datetime.date.today() - timedelta(days = 14))
+  dict_covid = {}
+
+  for state in state_codes:
+    new= df[(df['state'] == state) & (df['submission_date'] > last_week)]
+    new_cases= new['new_case'].astype('float').sum()
+    dict_covid[state] = new_cases
+  df = pd.DataFrame.from_dict(dict_covid, orient='index')
+  df.reset_index()
+  df2 = pd.DataFrame.from_dict(state_pops, orient='index')
+  df2.reset_index()
+  df3 = pd.concat([df, df2], axis=1)
+  df3.columns = ['covid_cases', 'population']
+  empty_list = []
+  length = len(df3)
+  for i in range(0, length):
+    empty_list.append(df3.iloc[i][0]/df3.iloc[i][1])
+  df3['covid_case_per_pop'] = empty_list
+  df3 = df3.reset_index()
+
+  return df3

--- a/project/requirements.txt
+++ b/project/requirements.txt
@@ -7,3 +7,4 @@ scikit-learn==0.23.2
 requests==2.24.0
 python-dotenv==0.15.0
 psycopg2-binary==2.8.6
+pytz==2020.5


### PR DESCRIPTION
Draft PR that attempts to enable the fetching of state level (all US states) covid deltas (e.g. over 14 days) from the database.

This PR includes:

- a route `/gen_covid_deltas` that calls a function to store today's state level covid data in the database.  This can triggered via cron job/trigger on a nightly basis (TBD).  This data then can be fetched to speed up processing
- a function `calc_covid_deltas_db` that when called to return the state level covid data, will first look in the database.  If that data is not found then it will be generated "from scratch"
- updates Robin's code to call `calc_covid_deltas_db` to take advantage of the database query